### PR TITLE
Handle async delegate failures and contract panics

### DIFF
--- a/agent/src/tools/delegation.py
+++ b/agent/src/tools/delegation.py
@@ -47,7 +47,10 @@ def delegate(vault_id: str, validator: str, amount: str) -> None:
                 amount=YOCTO_1,          # 1 yoctoNEAR deposit
             )
         )
-        
+        # Compute common details once for reuse in branches
+        tx_hash  = response.transaction.hash
+        explorer = get_explorer_url()
+
         # Inspect execution outcome for Failure / Panic
         failure = get_failure_message_from_tx_status(response.status)
         if failure:
@@ -61,8 +64,6 @@ def delegate(vault_id: str, validator: str, amount: str) -> None:
         evt_failed = find_event_data(response.logs, "delegate_failed")
         if evt_failed is not None:
             err = evt_failed.get("error", "delegate_failed")
-            tx_hash = response.transaction.hash
-            explorer = get_explorer_url()
             env.add_reply(
                 "❌ Delegate failed during async staking call.\n\n"
                 f"Vault [`{vault_id}`]({explorer}/accounts/{vault_id}) → "
@@ -73,9 +74,7 @@ def delegate(vault_id: str, validator: str, amount: str) -> None:
             return
 
         # Extract only the primitive fields we care about
-        tx_hash  = response.transaction.hash
         gas_tgas = response.transaction_outcome.gas_burnt / 1e12
-        explorer = get_explorer_url()
 
         env.add_reply(
             "✅ **Delegation Successful**\n"

--- a/agent/src/tools/delegation.py
+++ b/agent/src/tools/delegation.py
@@ -3,7 +3,7 @@ import json
 from decimal import Decimal
 from logging import Logger
 from .context import get_env, get_near, get_logger
-from helpers import YOCTO_FACTOR, signing_mode, run_coroutine, get_failure_message_from_tx_status, get_explorer_url
+from helpers import YOCTO_FACTOR, signing_mode, run_coroutine, get_failure_message_from_tx_status, get_explorer_url, find_event_data
 from runtime_constants import GAS_300_TGAS, YOCTO_1
 from py_near.models import TransactionResult
 
@@ -54,6 +54,21 @@ def delegate(vault_id: str, validator: str, amount: str) -> None:
             env.add_reply(
                 "❌ Delegate failed with **contract panic**:\n\n"
                f"> {json.dumps(failure, indent=2)}"
+            )
+            return
+
+        # Inspect async result via contract events
+        evt_failed = find_event_data(response.logs, "delegate_failed")
+        if evt_failed is not None:
+            err = evt_failed.get("error", "delegate_failed")
+            tx_hash = response.transaction.hash
+            explorer = get_explorer_url()
+            env.add_reply(
+                "❌ Delegate failed during async staking call.\n\n"
+                f"Vault [`{vault_id}`]({explorer}/accounts/{vault_id}) → "
+                f"`{validator}` for **{amount} NEAR**.\n"
+                f"Reason: `{err}`\n"
+                f"🔹 Tx: [{tx_hash}]({explorer}/transactions/{tx_hash})"
             )
             return
 
@@ -132,7 +147,7 @@ def undelegate(vault_id: str, validator: str, amount: str) -> None:
                f"> {json.dumps(failure, indent=2)}"
             )
             return
-        
+
         # Extract only the primitive fields we care about
         tx_hash  = response.transaction.hash
         gas_tgas = response.transaction_outcome.gas_burnt / 1e12


### PR DESCRIPTION
Enhances the delegate() function to detect and report failures emitted via contract events (delegate_failed) even when the transaction succeeds, and surfaces contract panic messages from status.Failure. Adds corresponding tests to ensure these error cases are properly handled and reported.

Closes #19 